### PR TITLE
Upgrade Spring Boot to 3.5.9 and Spring AI to 1.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
+	id 'org.springframework.boot' version '3.5.9'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -18,7 +18,7 @@ repositories {
 }
 
 ext {
-	set('springAiVersion', "1.1.0")
+	set('springAiVersion', "1.1.2")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Upgrade Spring Boot from 3.5.6 to 3.5.9 (patch release with bug fixes and security patches)
- Upgrade Spring AI from 1.1.0 to 1.1.2 (patch release with bug fixes)

## Test plan
- [ ] Verify build compiles successfully
- [ ] Run existing tests to ensure no regressions
- [ ] Test application startup and basic functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)