### PR TITLE
Remove PR trigger from container publish workflow

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Removed the `pull_request` trigger from the GitHub Container Registry publish workflow
- The workflow now only runs on push to the `main` branch, not on pull requests

## Test plan
- [ ] Verify the workflow no longer triggers on PR creation
- [ ] Verify the workflow still triggers when changes are pushed to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)