### PR TITLE
Change title bar color from blue to red

### DIFF
--- a/src/main/resources/static/custom.css
+++ b/src/main/resources/static/custom.css
@@ -31,7 +31,7 @@ body, html {
 }
 
 header {
-    background-color: #00364d;
+    background-color: #c41e3a;
     color: white;
     padding: 20px;
     display: inline-flex;


### PR DESCRIPTION
## Summary
- Changes the header/title bar background color from blue (#00364d) to red (#c41e3a)

Closes #10

## Test plan
- [ ] Open the application in a browser
- [ ] Verify the title bar displays in red instead of blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)